### PR TITLE
Add interactive competitive order UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,142 @@
-# laughing-winner
+# Competitive Order Management System Specification
+
+## Overview
+This specification defines the first implementation of a competitive, first-come-first-served order management system with admin
+ verification. Multiple users can attempt the same task, but only one verified winner is paid. The system prioritizes fairness,
+transparency, and concurrency safety, ensuring tasks close immediately upon admin-approved completion.
+
+## Roles
+- **Task Owner**: Authorized user who uploads tasks and funds payment.
+- **Participant**: User who discovers and attempts tasks.
+- **Admin/Reviewer**: Reviews submissions, approves the first valid completion, and triggers payment.
+
+## Task Lifecycle
+1. **Uploaded**: Owner creates task with requirements, deadline, completion criteria, and payment amount; status = `UPLOADED`.
+2. **Available**: Task is published to participants; status = `AVAILABLE`.
+3. **In-Progress**: Participants may claim (optional) and work; status remains `AVAILABLE`. Track start events without locking t
+he task to a single user.
+4. **Pending Review**: A participant submits completion; status = `PENDING_REVIEW`, but task stays open to receive other submiss
+ions until approval.
+5. **Approved/Completed**: Admin approves the first valid submission; status = `APPROVED`.
+6. **Closed**: Task locked against further submissions and displayed with winner info; status = `CLOSED`.
+7. **Reopened (Exceptional)**: If all submissions are rejected or payment fails irrecoverably, task may be reopened to `AVAILABL
+E` with version bump and audit trail.
+
+## Core Functional Requirements
+- **Task Upload Module**
+  - Create tasks with title, description, acceptance criteria, deadline, payment amount/currency, max attachments, and optional
+reference files.
+  - Require funding confirmation/escrow before task becomes `AVAILABLE`.
+  - Emit notifications to participants (based on preferences) when tasks go live.
+
+- **Submission Queue Management**
+  - Accept multiple submissions per task until closure.
+  - Capture submission artifacts (files/links), notes, and a precise submission timestamp.
+  - Maintain submission state: `PENDING_REVIEW`, `APPROVED`, `REJECTED`.
+  - Enforce immutability of submission content after receipt; allow admins to append feedback notes.
+
+- **Admin Verification Dashboard**
+  - List tasks with pending submissions ordered by oldest submission time.
+  - Provide side-by-side view of task requirements and submission artifacts.
+  - Actions: Approve (declares winner), Reject (with feedback), Request Resubmission (optional), Bulk reject all and reopen task
+.
+  - Show competing submissions and timestamps to support fair review.
+
+- **Winner Declaration & Payment**
+  - When admin clicks Approve, execute transactionally:
+    1. Lock task row and submission rows for update.
+    2. Confirm task not already closed/approved.
+    3. Mark selected submission `APPROVED`, others `REJECTED` with reason `Winner already approved`.
+    4. Update task status to `CLOSED`, set `winner_submission_id` and `winner_user_id`.
+    5. Trigger payment job with idempotent reference (task id + submission id).
+  - Payment flow must be idempotent and retried on transient failures; escalate and reopen task only on unrecoverable payment er
+rors.
+
+- **Task Closure Logic**
+  - Immediately broadcast task closure via websockets/push to all clients.
+  - Block new submissions once task status is `CLOSED`.
+  - Update list views to show winner, approval time, and payout confirmation.
+
+- **Timestamp Tracking & Audit Trail**
+  - Record: task upload time, publication time, participant start/claim events, submission time, admin review time, approval/rej
+ection time, payment initiation/completion time.
+  - Preserve immutable audit log entries for all state transitions and reviewer actions.
+
+- **User Notification System**
+  - Events: task uploaded/available, submission received, submission entered review, admin feedback, winner declared with paymen
+t confirmation, task closed by another winner, task reopened.
+  - Channels: in-app inbox, email, and optional push; include links to task and submission detail pages.
+
+## Data Model (Relational)
+- **users**(id, role, balance, payout_method, created_at, updated_at)
+- **tasks**(id, owner_id, title, description, acceptance_criteria, deadline_at, payment_amount, payment_currency, status, funded
+_at, published_at, winner_submission_id, winner_user_id, version, created_at, updated_at)
+- **task_assets**(id, task_id, url/path, type, created_at)
+- **task_events**(id, task_id, user_id, event_type, metadata JSON, created_at) — for audit trail (uploads, publishes, claims, su
+bmissions, approvals, reopens, payments).
+- **submissions**(id, task_id, user_id, content_blob/path, notes, status, submitted_at, reviewed_at, review_feedback, admin_id)
+- **submission_assets**(id, submission_id, url/path, type, created_at)
+- **payments**(id, task_id, submission_id, user_id, amount, currency, status, processor_ref, initiated_at, completed_at, failure
+_reason)
+
+Indexes: (tasks.status, tasks.deadline_at), (submissions.task_id, submissions.submitted_at), (payments.status), plus unique cons
+traint on `tasks.winner_submission_id` and `tasks.winner_user_id` per version.
+
+## Concurrency & Locking Strategy
+- Use database transactions with `SELECT ... FOR UPDATE` on the task row during approval to prevent double winners.
+- Use unique, idempotent payment key `(task_id, submission_id)` to avoid duplicate payouts.
+- Apply optimistic concurrency via task `version` for reopen scenarios; increment on reopen to invalidate stale clients.
+- Enforce submission cutoff by checking task status under lock before insert; if `CLOSED`, reject submission with error.
+
+## Business Rules
+- Participants may see submission count (configurable) but never submission contents until closure.
+- Optional soft-claim: participants can click “Start” to log intent; inactivity for N hours marks claim abandoned via scheduled
+job; task remains `AVAILABLE` throughout.
+- If all submissions rejected, owner/admin can reopen task: set status `AVAILABLE`, increment version, notify participants, and
+retain audit history.
+- If payment initiation fails transiently, retry with backoff; if irrecoverable, set task status `PAYMENT_FAILED`, notify admins
+, and pause further actions until manual resolution.
+- Prevent gaming: rate-limit submissions per user per task, require unique artifact hash check (where feasible), and log IP/devi
+ce fingerprints in `task_events`.
+- Dispute process: participants can file dispute referencing submission; admin can review logs and override outcomes; overrides
+recorded in audit trail with reason.
+
+## Interfaces
+- **Participant UI**: task list with status badges, countdown to deadline, submission count (if enabled), and real-time closure
+updates; submission form with upload progress and confirmation receipts.
+- **Admin Dashboard**: pending-review queue, task detail with all submissions sorted by time, approve/reject controls, and payme
+nt status monitor.
+- **Owner Console**: funding status, publication controls, and visibility into winner/payment outcomes.
+
+## Notification & Visibility Logic
+- Real-time updates via websockets; fallback to polling.
+- Status badges: `AVAILABLE`, `PENDING_REVIEW`, `APPROVED`, `CLOSED`, `PAYMENT_FAILED`, `REOPENED`.
+- Winner announcement shown on task detail with submission timestamp, approval time, and payout status.
+
+## Performance & Scalability
+- Paginate submission lists; store large artifacts in object storage with signed URLs.
+- Offload payment and notification sending to background workers with idempotent jobs.
+- Cache task list results with short TTL; invalidate on task update/closure events.
+
+## Operational Considerations
+- Monitoring: dashboards for pending-review backlog, approval latency, payment success rate.
+- Security: authorization checks for each action, malware scanning for uploads, and least-privilege access to payment credential
+s.
+- Backups: regular database backups and object storage lifecycle policies.
+- Compliance: retain audit logs for configured retention period; allow export for disputes.
+
+## Interactive Mock Interface
+A lightweight, client-only interface demonstrates the participant and admin workflows side by side. It uses in-memory data to si
+mulate submissions, approvals, and instant task closure after a winner is chosen.
+
+### Running the demo
+1. Serve the static files locally: `python -m http.server 8000`.
+2. Open `http://localhost:8000` in your browser.
+3. Use the participant panel to submit work; use the admin panel to approve or reject. Approving immediately closes the task, re
+jects competitors, and logs payment notifications.
+
+### What you can simulate
+- Competing submissions on the same task queued for admin review.
+- Admin approval that declares a single winner, triggers a mock payment, and instantly blocks further submissions.
+- Rejections that reopen the task when no pending submissions remain.
+- Notification feed mirroring submission receipts, approvals, closures, and payments.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,431 @@
+const tasks = [
+  {
+    id: "T-1042",
+    title: "Draft marketing one-pager",
+    description: "Summarize the new launch in one page with CTA and pricing table.",
+    acceptance: "Meets brief, no typos, includes CTA and updated pricing.",
+    deadline: addMinutes(new Date(), 180),
+    payment: "$250",
+    status: "AVAILABLE",
+    version: 1,
+    publishedAt: minutesAgo(40),
+    fundedAt: minutesAgo(45),
+    winnerSubmissionId: null,
+    winnerUserId: null,
+  },
+  {
+    id: "T-1043",
+    title: "Bug triage sweep",
+    description: "Validate reported bugs, reproduce, and add repro steps.",
+    acceptance: "At least 10 tickets triaged with repro steps in tracker.",
+    deadline: addMinutes(new Date(), 60),
+    payment: "$120",
+    status: "PENDING_REVIEW",
+    version: 1,
+    publishedAt: minutesAgo(25),
+    fundedAt: minutesAgo(30),
+    winnerSubmissionId: null,
+    winnerUserId: null,
+  },
+];
+
+const submissions = [
+  {
+    id: "S-5001",
+    taskId: "T-1043",
+    user: "Patricia",
+    notes: "Reviewed 12 tickets, added repro GIFs.",
+    status: "PENDING_REVIEW",
+    submittedAt: minutesAgo(10),
+    reviewedAt: null,
+    feedback: null,
+    admin: null,
+    content: "Link: https://tracker.local/batch-12",
+  },
+  {
+    id: "S-5002",
+    taskId: "T-1043",
+    user: "Sam",
+    notes: "Triaged 10 issues, added labels.",
+    status: "PENDING_REVIEW",
+    submittedAt: minutesAgo(6),
+    reviewedAt: null,
+    feedback: null,
+    admin: null,
+    content: "Link: https://tracker.local/sam-triage",
+  },
+];
+
+let selectedTaskId = null;
+let selectedSubmissionId = null;
+let notificationFeed = [];
+
+// Utilities
+function minutesAgo(mins) {
+  return new Date(Date.now() - mins * 60 * 1000);
+}
+
+function addMinutes(date, mins) {
+  return new Date(date.getTime() + mins * 60 * 1000);
+}
+
+function formatDate(date) {
+  return new Intl.DateTimeFormat("en", {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function formatStatus(status) {
+  switch (status) {
+    case "AVAILABLE":
+      return { label: "Available", className: "available", dot: "open" };
+    case "PENDING_REVIEW":
+      return { label: "Pending review", className: "pending", dot: "pending" };
+    case "CLOSED":
+      return { label: "Closed", className: "closed", dot: "closed" };
+    case "APPROVED":
+      return { label: "Approved", className: "closed", dot: "closed" };
+    case "REJECTED":
+      return { label: "Rejected", className: "rejected", dot: "rejected" };
+    default:
+      return { label: status, className: "", dot: "" };
+  }
+}
+
+function renderTasks() {
+  const container = document.getElementById("task-list");
+  container.innerHTML = "";
+
+  tasks.forEach((task) => {
+    const card = document.createElement("div");
+    card.className = `task-card ${selectedTaskId === task.id ? "active" : ""}`;
+    card.onclick = () => {
+      selectedTaskId = task.id;
+      selectedSubmissionId = getTaskPendingSubmissions(task.id)[0]?.id || null;
+      renderAll();
+    };
+
+    const status = formatStatus(task.status);
+    card.innerHTML = `
+      <div class="badges">
+        <span class="badge ${status.className}">${status.label}</span>
+        <span class="badge payment">Payment ${task.payment}</span>
+      </div>
+      <h4>${task.title}</h4>
+      <p class="meta">Deadline • ${formatDate(task.deadline)}</p>
+      <p class="meta">Published • ${formatDate(task.publishedAt)}</p>
+    `;
+
+    container.appendChild(card);
+  });
+}
+
+function renderTaskDetail() {
+  const task = tasks.find((t) => t.id === selectedTaskId);
+  const detail = document.getElementById("task-detail");
+
+  if (!task) {
+    detail.innerHTML = `<p class="meta">Select a task to view details.</p>`;
+    return;
+  }
+
+  const status = formatStatus(task.status);
+  const winner = task.winnerUserId ? `<p class="meta">Winner • ${task.winnerUserId}</p>` : "";
+
+  const pendingCount = submissions.filter(
+    (s) => s.taskId === task.id && s.status === "PENDING_REVIEW"
+  ).length;
+
+  detail.innerHTML = `
+    <div class="status-row">
+      <div class="status-dot ${status.dot}"></div>
+      <p class="meta"><strong>Status:</strong> ${status.label}</p>
+    </div>
+    <h3>${task.title}</h3>
+    <p class="meta">Payment • ${task.payment}</p>
+    <p class="meta">Deadline • ${formatDate(task.deadline)} | Published • ${formatDate(task.publishedAt)}</p>
+    <p class="meta">Acceptance • ${task.acceptance}</p>
+    <p>${task.description}</p>
+    <p class="meta">Submissions waiting review • ${pendingCount}</p>
+    ${winner}
+  `;
+}
+
+function renderSubmissionForm() {
+  const formCard = document.getElementById("submission-form");
+  const task = tasks.find((t) => t.id === selectedTaskId);
+  if (!task) {
+    formCard.innerHTML = `<p class="meta">Choose a task before submitting.</p>`;
+    return;
+  }
+  const closed = task.status === "CLOSED" || task.status === "APPROVED";
+
+  formCard.innerHTML = `
+    <h3>Submit completion</h3>
+    ${closed ? `<p class="alert">Task closed to new submissions.</p>` : ""}
+    <form id="submit-form">
+      <div>
+        <label for="participant-name">Your name</label>
+        <input id="participant-name" name="name" placeholder="Patricia" required />
+      </div>
+      <div>
+        <label for="artifact">Work link</label>
+        <input id="artifact" name="artifact" placeholder="https://..." required />
+      </div>
+      <div>
+        <label for="notes">Notes</label>
+        <textarea id="notes" name="notes" rows="3" placeholder="Summary of what you completed"></textarea>
+      </div>
+      <button type="submit" ${closed ? "disabled" : ""}>Send submission</button>
+    </form>
+  `;
+
+  const form = document.getElementById("submit-form");
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (closed) return;
+
+    const data = new FormData(form);
+    const submission = {
+      id: `S-${Math.floor(Math.random() * 9000 + 1000)}`,
+      taskId: task.id,
+      user: data.get("name") || "Anon",
+      notes: data.get("notes") || "",
+      status: "PENDING_REVIEW",
+      submittedAt: new Date(),
+      reviewedAt: null,
+      feedback: null,
+      admin: null,
+      content: data.get("artifact"),
+    };
+
+    if (task.status === "CLOSED") {
+      pushNotification("Submission blocked", `${submission.user}'s submission rejected because the task is closed.`);
+      return;
+    }
+
+    submissions.push(submission);
+    selectedSubmissionId = submission.id;
+    if (task.status === "AVAILABLE") task.status = "PENDING_REVIEW";
+    pushNotification("Submission received", `${submission.user} submitted ${task.id} at ${formatDate(submission.submittedAt)}.`);
+    renderAll();
+    form.reset();
+  });
+}
+
+function getTaskPendingSubmissions(taskId) {
+  return submissions
+    .filter((s) => s.taskId === taskId && s.status === "PENDING_REVIEW")
+    .sort((a, b) => a.submittedAt - b.submittedAt);
+}
+
+function renderQueue() {
+  const queueContainer = document.getElementById("review-queue");
+  queueContainer.innerHTML = "";
+
+  const pending = submissions.filter((s) => s.status === "PENDING_REVIEW");
+  pending.sort((a, b) => a.submittedAt - b.submittedAt);
+
+  document.getElementById("queue-meta").textContent = `${pending.length} awaiting review`;
+
+  if (!pending.length) {
+    const emptyState = document.createElement("p");
+    emptyState.className = "meta";
+    emptyState.textContent = "No submissions waiting for review.";
+    queueContainer.appendChild(emptyState);
+    return;
+  }
+
+  pending.forEach((sub) => {
+    const task = tasks.find((t) => t.id === sub.taskId);
+    const card = document.createElement("div");
+    card.className = `task-card ${selectedSubmissionId === sub.id ? "active" : ""}`;
+    card.onclick = () => {
+      selectedSubmissionId = sub.id;
+      selectedTaskId = sub.taskId;
+      renderAll();
+    };
+
+    card.innerHTML = `
+      <div class="badges">
+        <span class="badge pending">Pending review</span>
+        <span class="badge">${task.title}</span>
+      </div>
+      <h4>${sub.user}'s submission</h4>
+      <p class="meta">Submitted • ${formatDate(sub.submittedAt)}</p>
+      <p class="meta">Task • ${task.id} (${task.payment})</p>
+    `;
+
+    queueContainer.appendChild(card);
+  });
+}
+
+function renderReviewDetail() {
+  const container = document.getElementById("review-detail");
+  const submission = submissions.find((s) => s.id === selectedSubmissionId);
+
+  if (!submission) {
+    container.innerHTML = `<p class="meta">Select a submission to review.</p>`;
+    return;
+  }
+
+  const task = tasks.find((t) => t.id === submission.taskId);
+  const status = formatStatus(submission.status);
+
+  container.innerHTML = `
+    <div class="status-row">
+      <div class="status-dot ${status.dot}"></div>
+      <p class="meta"><strong>${status.label}</strong> • ${task.title}</p>
+    </div>
+    <h3>${submission.user}'s work</h3>
+    <p class="meta">Submitted • ${formatDate(submission.submittedAt)}</p>
+    <p class="meta">Content • ${submission.content}</p>
+    <p>${submission.notes}</p>
+    <div class="badges">
+      <span class="badge">Task ${task.id}</span>
+      <span class="badge payment">Payment ${task.payment}</span>
+    </div>
+    <div class="action-row">
+      <button id="approve">Approve & pay</button>
+      <button class="secondary" id="reject">Reject</button>
+      <button class="secondary" id="reopen" ${task.status === "CLOSED" && !task.winnerSubmissionId ? "" : "disabled"}>Reopen task</button>
+    </div>
+  `;
+
+  document.getElementById("approve").onclick = () => approveSubmission(submission.id);
+  document.getElementById("reject").onclick = () => rejectSubmission(submission.id);
+  document.getElementById("reopen").onclick = () => reopenTask(task.id);
+}
+
+function approveSubmission(submissionId) {
+  const submission = submissions.find((s) => s.id === submissionId);
+  const task = tasks.find((t) => t.id === submission.taskId);
+  if (!submission || !task) return;
+  if (task.status === "CLOSED") return;
+
+  task.status = "CLOSED";
+  task.winnerSubmissionId = submission.id;
+  task.winnerUserId = submission.user;
+
+  submission.status = "APPROVED";
+  submission.reviewedAt = new Date();
+  submission.admin = "Admin";
+
+  submissions
+    .filter((s) => s.taskId === task.id && s.id !== submission.id && s.status === "PENDING_REVIEW")
+    .forEach((s) => {
+      s.status = "REJECTED";
+      s.reviewedAt = new Date();
+      s.feedback = "Winner already approved";
+      s.admin = "Admin";
+    });
+
+  pushNotification("Winner declared", `${submission.user} wins ${task.id}. Payment triggered.`);
+  pushNotification("Task closed", `${task.id} closed immediately after approval.`);
+  simulatePayment(task, submission);
+  renderAll();
+}
+
+function rejectSubmission(submissionId) {
+  const submission = submissions.find((s) => s.id === submissionId);
+  const task = tasks.find((t) => t.id === submission.taskId);
+  if (!submission || !task) return;
+
+  submission.status = "REJECTED";
+  submission.reviewedAt = new Date();
+  submission.admin = "Admin";
+  submission.feedback = "Does not meet acceptance criteria";
+
+  if (!getTaskPendingSubmissions(task.id).length) {
+    task.status = "AVAILABLE";
+    pushNotification("Task reopened", `${task.id} reopened after all submissions rejected.`);
+  }
+
+  pushNotification("Submission rejected", `${submission.user}'s submission rejected.`);
+  renderAll();
+}
+
+function reopenTask(taskId) {
+  const task = tasks.find((t) => t.id === taskId);
+  if (!task) return;
+  task.status = "AVAILABLE";
+  task.version += 1;
+  task.winnerSubmissionId = null;
+  task.winnerUserId = null;
+  pushNotification("Task reopened", `${task.id} reopened with version ${task.version}.`);
+  renderAll();
+}
+
+function simulatePayment(task, submission) {
+  setTimeout(() => {
+    pushNotification("Payment completed", `${submission.user} paid ${task.payment} for ${task.id}.`);
+  }, 600);
+}
+
+function pushNotification(tag, message) {
+  notificationFeed.unshift({
+    id: crypto.randomUUID(),
+    tag,
+    message,
+    time: new Date(),
+  });
+  renderFeed();
+}
+
+function renderFeed() {
+  const feed = document.getElementById("notification-feed");
+  feed.innerHTML = "";
+
+  notificationFeed.slice(0, 30).forEach((item) => {
+    const node = document.createElement("div");
+    node.className = "feed-item";
+    node.innerHTML = `
+      <div>
+        <div class="tag">${item.tag}</div>
+        <div class="time">${formatDate(item.time)}</div>
+      </div>
+      <p class="message">${item.message}</p>
+    `;
+    feed.appendChild(node);
+  });
+}
+
+function renderAll() {
+  renderTasks();
+  renderTaskDetail();
+  renderSubmissionForm();
+  renderQueue();
+  renderReviewDetail();
+  renderFeed();
+}
+
+function bootstrapFeed() {
+  pushNotification("System", "Workspace initialized with mock data.");
+  pushNotification("Tasks", "Two tasks published to participants.");
+  pushNotification("Queue", "Submissions awaiting admin verification.");
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("refresh-btn").onclick = renderAll;
+  document.getElementById("clear-log").onclick = () => {
+    notificationFeed = [];
+    renderFeed();
+  };
+  initializeSelection();
+  bootstrapFeed();
+  renderAll();
+});
+
+function initializeSelection() {
+  const firstTaskId = tasks[0]?.id;
+  const earliestPending =
+    (firstTaskId ? getTaskPendingSubmissions(firstTaskId)[0] : null) ||
+    submissions.slice().sort((a, b) => a.submittedAt - b.submittedAt)[0];
+  if (earliestPending) {
+    selectedSubmissionId = earliestPending.id;
+    selectedTaskId = earliestPending.taskId;
+  } else {
+    selectedTaskId = tasks[0]?.id || null;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Competitive Order Management UI</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <div>
+      <p class="eyebrow">Demo workspace</p>
+      <h1>Competitive Order Management</h1>
+      <p class="lede">Explore participant and admin flows for competitive task completion with verified winners.</p>
+    </div>
+    <div class="status-pill">Real-time mock data</div>
+  </header>
+
+  <main class="layout">
+    <section class="panel participant" aria-labelledby="participant-title">
+      <div class="panel-header">
+        <div>
+          <p class="eyebrow">Participant</p>
+          <h2 id="participant-title">Task board</h2>
+        </div>
+        <button class="secondary" id="refresh-btn">Sync</button>
+      </div>
+      <div class="columns">
+        <div class="column tasks">
+          <h3>Open tasks</h3>
+          <div id="task-list" class="list"></div>
+        </div>
+        <div class="column details">
+          <div class="detail-card" id="task-detail" aria-live="polite"></div>
+          <div class="card" id="submission-form"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel admin" aria-labelledby="admin-title">
+      <div class="panel-header">
+        <div>
+          <p class="eyebrow">Admin</p>
+          <h2 id="admin-title">Verification & approvals</h2>
+        </div>
+        <div class="queue-meta" id="queue-meta"></div>
+      </div>
+      <div class="columns">
+        <div class="column queue">
+          <h3>Pending review</h3>
+          <div id="review-queue" class="list"></div>
+        </div>
+        <div class="column review">
+          <div class="detail-card" id="review-detail" aria-live="polite"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel notifications" aria-labelledby="notifications-title">
+      <div class="panel-header">
+        <div>
+          <p class="eyebrow">Activity</p>
+          <h2 id="notifications-title">Notifications & audit</h2>
+        </div>
+        <button class="secondary" id="clear-log">Clear log</button>
+      </div>
+      <div id="notification-feed" class="feed" aria-live="polite"></div>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,225 @@
+:root {
+  --bg: #0b1021;
+  --panel: #0f152b;
+  --card: #141c36;
+  --stroke: #24314f;
+  --text: #e8edf8;
+  --muted: #9fb1d9;
+  --accent: #6cf0c2;
+  --danger: #ff7b7b;
+  --warning: #ffd479;
+  --shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+  --radius: 14px;
+  --radius-sm: 10px;
+  --gap: 18px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(108, 240, 194, 0.07), transparent 30%),
+              radial-gradient(circle at 80% 0%, rgba(126, 164, 255, 0.08), transparent 32%),
+              var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 28px clamp(18px, 3vw, 42px);
+  gap: 14px;
+}
+
+.app-header h1 {
+  margin: 4px 0;
+  letter-spacing: -0.02em;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  font-size: 11px;
+  margin: 0;
+}
+
+.lede {
+  margin: 6px 0 0;
+  color: #d3ddf5;
+  max-width: 740px;
+}
+
+.status-pill {
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(108, 240, 194, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+  border: 1px solid rgba(108, 240, 194, 0.2);
+}
+
+.layout {
+  padding: 0 clamp(18px, 3vw, 42px) 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--stroke);
+  box-shadow: var(--shadow);
+  border-radius: var(--radius);
+  padding: 18px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-bottom: 1px solid var(--stroke);
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+}
+
+.columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: var(--gap);
+}
+
+.column h3 {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card, .detail-card {
+  background: var(--card);
+  border: 1px solid var(--stroke);
+  border-radius: var(--radius);
+  padding: 14px;
+}
+
+.detail-card h3 {
+  margin-top: 0;
+}
+
+.task-card {
+  padding: 14px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0));
+  border: 1px solid var(--stroke);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: transform 0.08s ease, border-color 0.08s ease;
+}
+
+.task-card:hover { transform: translateY(-2px); border-color: var(--accent); }
+.task-card.active { border-color: var(--accent); box-shadow: inset 0 0 0 1px rgba(108, 240, 194, 0.5); }
+
+.badges { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
+.badge {
+  padding: 6px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  border: 1px solid var(--stroke);
+  color: var(--muted);
+}
+
+.badge.available { color: var(--accent); border-color: rgba(108, 240, 194, 0.4); }
+.badge.pending { color: #ffd479; border-color: rgba(255, 212, 121, 0.5); }
+.badge.closed { color: #9fb1d9; }
+.badge.payment { color: #82c6ff; border-color: rgba(130, 198, 255, 0.5); }
+
+.meta { color: var(--muted); font-size: 14px; margin-top: 6px; }
+.meta strong { color: var(--text); }
+
+button {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 14px;
+  background: var(--accent);
+  color: #0b1233;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.08s ease, box-shadow 0.08s ease;
+  box-shadow: 0 10px 20px rgba(108, 240, 194, 0.2);
+}
+
+button:hover { transform: translateY(-1px); }
+button:disabled { opacity: 0.5; cursor: not-allowed; box-shadow: none; transform: none; }
+
+button.secondary {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--stroke);
+  box-shadow: none;
+}
+
+form {
+  display: grid;
+  gap: 10px;
+}
+
+label { display: block; font-weight: 600; margin-bottom: 4px; }
+input, textarea, select {
+  width: 100%;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid var(--stroke);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text);
+}
+
+.feed { display: flex; flex-direction: column; gap: 10px; }
+
+.feed-item {
+  border: 1px solid var(--stroke);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.02);
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 10px;
+}
+
+.feed-item .tag { font-weight: 700; color: var(--muted); }
+.feed-item .message { margin: 0; }
+.feed-item .time { color: var(--muted); font-size: 12px; }
+
+.queue-meta { color: var(--muted); }
+
+.submission-card {
+  border: 1px dashed var(--stroke);
+  border-radius: var(--radius-sm);
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+.status-row { display: flex; align-items: center; gap: 10px; margin: 10px 0; }
+.status-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: var(--muted);
+}
+.status-dot.open { background: var(--accent); }
+.status-dot.pending { background: #ffd479; }
+.status-dot.closed { background: #9fb1d9; }
+.status-dot.rejected { background: var(--danger); }
+
+.alert { color: var(--danger); font-weight: 700; }
+
+@media (max-width: 900px) {
+  .feed-item { grid-template-columns: 1fr; }
+  .panel-header { flex-direction: column; align-items: flex-start; }
+}


### PR DESCRIPTION
## Summary
- add a static participant/admin demo UI showing competitive submission flows
- style the layout for side-by-side task board, review queue, and notification feed
- document how to run the mock interface alongside the system specification
- improve admin queue defaults with safer initial selection, empty queue messaging, and null-safe rendering

## Testing
- python -m http.server 8000


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69297bb9c530832dbe0cdc2a60c589c0)